### PR TITLE
Specify Supabase server URL in env, just like `SUPABASE_KEY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ The `master` branch version of the proxy requires Redis & Supabase for rate-limi
 ## Environment variables & pre-requisites
 
 1. `SERVER_URL`: The URL where your server is runnning (used for serving static files). For example, if you are running the server locally it will be `localhost:3000` and if your server is live at `abc.xyz`, the value for this variable will be `abc.xyz`. This variable is necessary to serve static files correctly.
-2. `SUPABASE_KEY`: Your Supabase project's anon key. This proxy uses Supabase to cache query results. You will need to (i) Create a new project on [Supabase](https://app.supabase.io), (ii) Create a new table called `meta-cache` and create the following columns: `url` (text), `title` (text), `description` (text), `siteName` (text), `image` (text), `hostname` (text).
-3. Redis. If you're deploying to Heroku, you can use the [Redis To Go](https://elements.heroku.com/addons/redistogo) add-on. 
+2. `SUPABASE_URL`: Your Supabase database url, typically in the format `https://somelongstringhere.supabase.co`
+3. `SUPABASE_KEY`: Your Supabase project's anon key. This proxy uses Supabase to cache query results. You will need to (i) Create a new project on [Supabase](https://app.supabase.io), (ii) Create a new table called `meta-cache` and create the following columns: `url` (text), `title` (text), `description` (text), `siteName` (text), `image` (text), `hostname` (text).
+4. Redis. If you're deploying to Heroku, you can use the [Redis To Go](https://elements.heroku.com/addons/redistogo) add-on. 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { APIOutput } from '../types';
 
-const SUPABASE_URL = 'https://iqdsdnumpussaltfrvgb.supabase.co';
+const SUPABASE_URL = process.env.SUPABASE_URL!;
 
 const supabase = createClient(SUPABASE_URL, process.env.SUPABASE_KEY!);
 


### PR DESCRIPTION
Moves the `SUPABASE_URL` property to environment variables, instead of it being hardcoded in [src/lib/cache.ts](https://github.com/Dhaiwat10/rlp-proxy/blob/5c18415247ea35aeccf07d1cffea87a85fb0760a/src/lib/cache.ts#L4).